### PR TITLE
Revised Implementation

### DIFF
--- a/lib/lita/adapters/flowdock/message_handler.rb
+++ b/lib/lita/adapters/flowdock/message_handler.rb
@@ -39,14 +39,6 @@ module Lita
             return content.is_a?(Hash) ? content['text'] : content
           end
 
-          def tags
-            data['tags']
-          end
-
-          def thread_id
-            data['thread_id']
-          end
-
           def dispatch_message(user)
             source = FlowdockSource.new(
               user: user,
@@ -54,7 +46,7 @@ module Lita
               private_message: private_message?,
               message_id: private_message? ? data['id'] : data['thread']['initial_message']
             )
-            message = FlowdockMessage.new(robot, body, source, tags, thread_id)
+            message = FlowdockMessage.new(robot, body, source, data)
             robot.receive(message)
           end
 

--- a/lib/lita/message/flowdock_message.rb
+++ b/lib/lita/message/flowdock_message.rb
@@ -1,10 +1,23 @@
 module Lita
   class FlowdockMessage < Message
-    attr_reader :tags, :thread_id
-    def initialize(robot, body, source, tags, thread_id)
-      @tags = tags
-      @thread_id = thread_id
+
+    attr_reader :data
+
+    def initialize(robot, body, source, data)
+      @data = data
       super(robot, body, source)
+    end
+
+    def tags
+      @data['tags']
+    end
+
+    def thread_id
+      @data['thread_id']
+    end
+
+    def new_thread?
+      @data['id'] == @data['thread']['initial_message']
     end
   end
 end

--- a/spec/lita/adapters/flowdock/message_handler_spec.rb
+++ b/spec/lita/adapters/flowdock/message_handler_spec.rb
@@ -52,7 +52,7 @@ describe Lita::Adapters::Flowdock::MessageHandler, lita: true do
           message_id: id
         ).and_return(source)
         allow(Lita::FlowdockMessage).to receive(:new).with(
-          robot, 'Hello World!', source, [], nil).and_return(message)
+          robot, 'Hello World!', source, data).and_return(message)
         allow(robot).to receive(:receive).with(message)
       end
 
@@ -81,8 +81,7 @@ describe Lita::Adapters::Flowdock::MessageHandler, lita: true do
             robot,
             "",
             source,
-            [],
-            nil
+            data
           ).and_return(message)
 
           subject.handle
@@ -244,7 +243,7 @@ describe Lita::Adapters::Flowdock::MessageHandler, lita: true do
           message_id: parent_id
         ).and_return(source)
         allow(Lita::FlowdockMessage).to receive(:new).with(
-          robot, 'Lita: help', source, tags, nil).and_return(message)
+          robot, 'Lita: help', source, data).and_return(message)
         allow(robot).to receive(:receive).with(message)
       end
 

--- a/spec/lita/message/flowdock_message_spec.rb
+++ b/spec/lita/message/flowdock_message_spec.rb
@@ -32,17 +32,19 @@ describe Lita::FlowdockMessage, lita: true do
 
   context "a message" do
     let(:body) { 'the system is #down' }
+    let(:initial_message){ 1234 }
     let(:data) do
       {
         'content'         => {
           'title'         => 'Thread title',
           'text'          => body
         },
+        'thread_id'       => 'a385473',
         'event'           => 'comment',
         'flow'            => test_flow,
         'id'              => 2345,
         'thread'          => {
-          'initial_message' => 1234
+          'initial_message' => initial_message
         },
         'tags'            => ['down'],
         'user'            => 3
@@ -58,6 +60,32 @@ describe Lita::FlowdockMessage, lita: true do
       )
 
       message_handler.handle
+    end
+
+    context 'instance methods' do
+      subject{ Lita::FlowdockMessage.new( robot, body, source, data) }
+      it 'has #tags' do
+        expect(subject.tags).to eq(['down'])
+      end
+
+      it 'has #thread_id' do
+        expect(subject.thread_id).to eq('a385473')
+      end
+
+      context 'new_thread?' do
+        context 'non new-thread' do
+          it 'is false' do
+            expect(subject.new_thread?).to be false
+          end
+        end
+
+        context 'a new thread' do
+          let(:initial_message){ 2345 }
+          it 'is true' do
+            expect(subject.new_thread?).to be true
+          end
+        end
+      end
     end
   end
 end

--- a/spec/lita/message/flowdock_message_spec.rb
+++ b/spec/lita/message/flowdock_message_spec.rb
@@ -30,8 +30,7 @@ describe Lita::FlowdockMessage, lita: true do
     allow(Lita::User).to receive(:find_by_id).and_return(user)
   end
 
-  context "a message in a thread has a tag" do
-    let(:tags) { ['down'] }
+  context "a message" do
     let(:body) { 'the system is #down' }
     let(:data) do
       {
@@ -45,82 +44,17 @@ describe Lita::FlowdockMessage, lita: true do
         'thread'          => {
           'initial_message' => 1234
         },
-        'tags'            => tags,
+        'tags'            => ['down'],
         'user'            => 3
       }
     end
 
-    it 'creates a message with tags' do
+    it 'creates a message with data' do
       expect(Lita::FlowdockMessage).to receive(:new).with(
         robot,
         body,
         source,
-        tags,
-        nil
-      )
-
-      message_handler.handle
-    end
-  end
-
-  context "a message in a thread" do
-    let(:tags) { ['down'] }
-    let(:body) { 'the system is #down' }
-    let(:data) do
-      {
-        'content'         => {
-          'title'         => 'Thread title',
-          'text'          => body
-        },
-        'event'           => 'comment',
-        'flow'            => test_flow,
-        'id'              => 2345,
-        'thread_id'     => 'deadbeef',
-        'thread'          => {
-          'initial_message' => 1234
-        },
-        'tags'            => tags,
-        'user'            => 3
-      }
-    end
-
-    it 'stores the message_id on the flowdock_message' do
-      expect(Lita::FlowdockMessage).to receive(:new).with(
-        robot,
-        body,
-        source,
-        tags,
-        'deadbeef'
-      )
-
-      message_handler.handle
-    end
-  end
-
-  context 'a regular message with a tag' do
-    let(:tags) { ['world'] }
-    let(:body) { 'Hello #world' }
-    let(:data) do
-      {
-        'content'         => body,
-        'event'           => 'message',
-        'flow'            => test_flow,
-        'id'              => 1234,
-        'thread'          => {
-          'initial_message' => 1234
-        },
-        'tags'            => tags,
-        'user'            => 3
-      }
-    end
-
-    it 'creates a message with tags' do
-      expect(Lita::FlowdockMessage).to receive(:new).with(
-        robot,
-        body,
-        source,
-        tags,
-        nil
+        data
       )
 
       message_handler.handle


### PR DESCRIPTION
I kept finding myself needing more and more of the raw information from the Flowdock API. Instead adding those as attributes that get evaluated by the message_handler (and thus making things waaay more complicated) this seemed like the better approach.

Let's store the data (the hash for the incoming event) in the FlowdockMessage object. Then we can add methods to the message so that we can interrogate the message inside other addons.

This creates three useful methods:

FlowdockMessage#tags returns data['tags']

FlowdockMessage#thread_id returns data['thread_id']

FlowdockMessage#new_thread? returns data['id'] == data['thread']['initial_message']

If we wanted to add other methods we could do so easily.
