### PR TITLE
Better rooming by storing parameterized_name and id

### DIFF
--- a/lib/lita/adapters/flowdock/connector.rb
+++ b/lib/lita/adapters/flowdock/connector.rb
@@ -99,6 +99,7 @@ module Lita
           def store_flows
             client.get("/flows").each do |flow|
               Lita.redis.set("flows/#{flow['parameterized_name']}", flow['id'])
+              Lita.redis.set("flows_id/#{flow['id']}", flow['parameterized_name'])
             end
           end
       end

--- a/lib/lita/source/flowdock_source.rb
+++ b/lib/lita/source/flowdock_source.rb
@@ -3,9 +3,15 @@ module Lita
     attr_reader :message_id
 
     def initialize(user: nil, room: nil, private_message: false, message_id: nil)
-      room = Lita.redis.get("flows/#{room}") || room unless room.nil?
+      room = room_id_to_room_object(room)
       super(user: user, room: room, private_message: private_message)
       @message_id = message_id
+    end
+
+    def room_id_to_room_object(room)
+      return room unless Lita.redis.exists("flows_id/#{room}")
+      room_name = Lita.redis.get("flows_id/#{room}")
+      Room.new(room, {name: room_name})
     end
   end
 end

--- a/spec/lita/adapters/flowdock/connector_spec.rb
+++ b/spec/lita/adapters/flowdock/connector_spec.rb
@@ -41,6 +41,7 @@ describe Lita::Adapters::Flowdock::Connector, lita: true do
       allow(fd_client).to receive(:get).with('/users').and_return([])
       allow(fd_client).to receive(:get).with("/flows").and_return(flows)
       expect(Lita.redis).to receive(:set).with("flows/#{flows[0]['parameterized_name']}", flows[0]['id'])
+      expect(Lita.redis).to receive(:set).with("flows_id/#{flows[0]['id']}", flows[0]['parameterized_name'])
       subject.new(robot, api_token, organization, flows, fd_client)
     end
   end

--- a/spec/lita/source/flowdock_source_spec.rb
+++ b/spec/lita/source/flowdock_source_spec.rb
@@ -1,21 +1,24 @@
 require 'spec_helper'
+require 'pry-byebug'
 
 describe Lita::FlowdockSource do
-  let(:room){ "Main" }
+  let(:room){ Lita::Room.new(room_id, {name: "Main"}) }
   let(:room_id) { "123123123" }
 
-  subject{ Lita::FlowdockSource.new(room: room) }
+  subject{ Lita::FlowdockSource.new(room: room_id) }
 
   describe "with a room" do
     it "looks up rooms" do
-      expect(Lita.redis).to receive(:get).with("flows/#{room}").and_return(room_id)
-      expect(subject.room).to eql(room_id)
+      expect(Lita.redis).to receive(:exists).with("flows_id/#{room_id}").and_return(true)
+      expect(Lita.redis).to receive(:get).with("flows_id/#{room_id}").and_return("Main")
+      expect(subject.room_object.id).to eql(room_id)
+      expect(subject.room_object.name).to eql(room.name)
     end
 
     describe "if the room doesn't exist" do
       it "defaults to the passed in room" do
-        expect(Lita.redis).to receive(:get).with("flows/#{room}").and_return(nil)
-        expect(subject.room).to eql(room)
+        expect(Lita.redis).to receive(:exists).with("flows_id/#{room_id}").and_return(true)
+        expect(subject.room).to eql(room_id)
       end
     end
   end
@@ -32,7 +35,7 @@ describe Lita::FlowdockSource do
 
 
   describe "with a message id" do
-    subject{ Lita::FlowdockSource.new(room: room, message_id: 123) }
+    subject{ Lita::FlowdockSource.new(room: room_id, message_id: 123) }
 
     it "saves the message id" do
       allow(Lita.redis).to receive(:get).with("flows/#{room}").and_return(room_id)


### PR DESCRIPTION
Description: The flowdock realtime streaming api only sends the flow id, not the flow's parameterized name. If you are going to use Lita in conjunction with the Flowdock Client Gem you'll need the parameterized name in order to do anything. 

Redis Keys Used: 

flows/parameterized_name => id

flows_id/id => parameterized_name

This being done so that FlowdockSource can make a real room_object. From each room_object you can get:

source.room_object.name = Parameterized Name
source.room_object.id = id
