### PR TITLE
replay_edits

### DIFF
--- a/lib/lita/adapters/flowdock.rb
+++ b/lib/lita/adapters/flowdock.rb
@@ -12,6 +12,7 @@ module Lita
       config :thread_responses, type: Symbol, required: false, default: :enabled
       config :private_messages, type: Symbol, required: false, default: :enabled
       config :active_user, type: Symbol, required: false, default: :enabled
+      config :replay_edits, type: Symbol, required: false, default: :disabled
 
 
       def mention_format(name)

--- a/lib/lita/message/flowdock_message.rb
+++ b/lib/lita/message/flowdock_message.rb
@@ -9,7 +9,8 @@ module Lita
     end
 
     def tags
-      @data['tags']
+      binding.pry
+      @data['tags'].any? ? data['tags'] : body.scan(/(?<=\s|\A)#(.*?)(?=\s|\z)/).flatten
     end
 
     def thread_id


### PR DESCRIPTION
WIP: Do not merge

This would allow you to replay an edit. The downside is that edit JSON isn't complete. It lacks:
- Thread ID
- Tags

``` ruby
{"event"=>"message-edit", "tags"=>[], "uuid"=>nil, "persist"=>false, "id"=>2467, "flow"=>"b822a5da-b6f4-4b65-b7c0-5d2352489c33", "content"=>{"message"=>2457, "updated_content"=>"fublam a s"}, "sent"=>1450127609863, "app"=>nil, "created_at"=>"2015-12-14T21:13:29.863Z", "attachments"=>[], "user"=>"20954"}
```

Due to this issue you can't really replay the message to any handlers without first augmenting the message with more information. 
